### PR TITLE
Refactor StartReplication methods

### DIFF
--- a/src/Npgsql/Replication/Logical/Internal/NpgsqlLogicalReplicationConnectionExtensions.cs
+++ b/src/Npgsql/Replication/Logical/Internal/NpgsqlLogicalReplicationConnectionExtensions.cs
@@ -121,12 +121,10 @@ namespace Npgsql.Replication.Logical.Internal
         /// <param name="options">The collection of options passed to the slot's logical decoding plugin.</param>
         /// <returns>A <see cref="Task{T}"/> representing an <see cref="IAsyncEnumerable{T}"/> that
         /// can be used to stream WAL entries in form of <see cref="NpgsqlXLogDataMessage"/> instances.</returns>
-        public static Task<IAsyncEnumerable<NpgsqlXLogDataMessage>> StartReplicationForPlugin(
+        public static IAsyncEnumerable<NpgsqlXLogDataMessage> StartReplicationForPlugin(
             this NpgsqlLogicalReplicationConnection connection, NpgsqlLogicalReplicationSlot slot, CancellationToken cancellationToken,
             NpgsqlLogSequenceNumber? walLocation = null, IEnumerable<KeyValuePair<string, string?>>? options = null)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<IAsyncEnumerable<NpgsqlXLogDataMessage>>(cancellationToken);
             using var _ = NoSynchronizationContextScope.Enter();
             return connection.StartReplicationInternal(commandBuilder =>
             {

--- a/src/Npgsql/Replication/Physical/NpgsqlPhysicalReplicationConnection.cs
+++ b/src/Npgsql/Replication/Physical/NpgsqlPhysicalReplicationConnection.cs
@@ -75,7 +75,7 @@ namespace Npgsql.Replication.Physical
         /// <param name="timeline">Streaming starts on timeline tli.</param>
         /// <returns>A <see cref="Task{T}"/> representing an <see cref="IAsyncEnumerable{NpgsqlXLogDataMessage}"/> that
         /// can be used to stream WAL entries in form of <see cref="NpgsqlXLogDataMessage"/> instances.</returns>
-        public Task<IAsyncEnumerable<NpgsqlXLogDataMessage>> StartReplication(
+        public IAsyncEnumerable<NpgsqlXLogDataMessage> StartReplication(
             NpgsqlPhysicalReplicationSlot slot, CancellationToken cancellationToken, NpgsqlLogSequenceNumber walLocation,
             uint timeline = default)
         {
@@ -84,7 +84,7 @@ namespace Npgsql.Replication.Physical
             {
                 commandBuilder.Append("SLOT ").Append(slot.SlotName).Append(' ');
                 AppendCommon(commandBuilder, walLocation, timeline);
-            }, false, cancellationToken);
+            }, bypassingStream: false, cancellationToken);
         }
 
         /// <summary>
@@ -102,12 +102,12 @@ namespace Npgsql.Replication.Physical
         /// <param name="timeline">Streaming starts on timeline tli.</param>
         /// <returns>A <see cref="Task{T}"/> representing an <see cref="IAsyncEnumerable{NpgsqlXLogDataMessage}"/> that
         /// can be used to stream WAL entries in form of <see cref="NpgsqlXLogDataMessage"/> instances.</returns>
-        public Task<IAsyncEnumerable<NpgsqlXLogDataMessage>> StartReplication(
+        public IAsyncEnumerable<NpgsqlXLogDataMessage> StartReplication(
             NpgsqlLogSequenceNumber walLocation, CancellationToken cancellationToken, uint timeline = default)
         {
             using var _ = NoSynchronizationContextScope.Enter();
             return StartReplicationInternal(commandBuilder => AppendCommon(commandBuilder, walLocation, timeline),
-                false, cancellationToken);
+                bypassingStream: false, cancellationToken);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -306,7 +306,7 @@ namespace Npgsql.Tests.Replication
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in StartReplication(rc, slotName, info.XLogPos, streamingCts.Token).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in StartReplication(rc, slotName, info.XLogPos, streamingCts.Token))
                         {
                             if (typeof(TConnection) == typeof(NpgsqlPhysicalReplicationConnection))
                             {
@@ -463,7 +463,7 @@ namespace Npgsql.Tests.Replication
             {
                 var slot = new NpgsqlPhysicalReplicationSlot(slotName);
                 var rc = (NpgsqlPhysicalReplicationConnection)(NpgsqlReplicationConnection)connection;
-                await foreach (var msg in (await rc.StartReplication(slot, cancellationToken, xLogPos)).WithCancellation(cancellationToken))
+                await foreach (var msg in rc.StartReplication(slot, cancellationToken, xLogPos))
                 {
                     yield return msg;
                 }
@@ -472,7 +472,7 @@ namespace Npgsql.Tests.Replication
             {
                 var slot = new NpgsqlTestDecodingReplicationSlot(slotName);
                 var rc = (NpgsqlLogicalReplicationConnection)(NpgsqlReplicationConnection)connection;
-                await foreach (var msg in (await rc.StartReplication(slot, cancellationToken, walLocation: xLogPos)).WithCancellation(cancellationToken))
+                await foreach (var msg in rc.StartReplication(slot, cancellationToken, walLocation: xLogPos))
                 {
                     yield return msg;
                 }

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -49,7 +49,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 
@@ -115,7 +115,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 
@@ -176,7 +176,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 
@@ -238,7 +238,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 
@@ -299,7 +299,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 
@@ -360,7 +360,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 
@@ -419,7 +419,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 
@@ -486,7 +486,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach (var msg in (await rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, new NpgsqlPgOutputPluginOptions(publicationName), streamingCts.Token))
                             messages.Enqueue(msg);
                     }, CancellationToken.None);
 

--- a/test/Npgsql.Tests/Replication/PhysicalReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PhysicalReplicationTests.cs
@@ -47,7 +47,7 @@ namespace Npgsql.Tests.Replication
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, streamingCts.Token, info.XLogPos)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token, info.XLogPos))
                         {
                             using var memoryStream = new MemoryStream();
                             await msg.Data.CopyToAsync(memoryStream, 4096, streamingCts.Token);
@@ -92,7 +92,7 @@ namespace Npgsql.Tests.Replication
             using var streamingCts = new CancellationTokenSource();
             var replicationTask = Task.Run(async () =>
             {
-                await foreach(var msg in (await rc.StartReplication(info.XLogPos, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                await foreach (var msg in rc.StartReplication(info.XLogPos, streamingCts.Token))
                 {
                     using var memoryStream = new MemoryStream();
                     await msg.Data.CopyToAsync(memoryStream, 4096, streamingCts.Token);

--- a/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
@@ -53,7 +53,7 @@ namespace Npgsql.Tests.Replication
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 
@@ -102,7 +102,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2')");
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 
@@ -151,7 +151,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 
@@ -196,7 +196,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 
@@ -240,7 +240,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 
@@ -287,7 +287,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 
@@ -333,7 +333,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 
@@ -378,7 +378,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
                     using var streamingCts = new CancellationTokenSource();
                     var replicationTask = Task.Run(async () =>
                     {
-                        await foreach(var msg in (await rc.StartReplication(slot, cancellationToken: streamingCts.Token)).WithCancellation(streamingCts.Token))
+                        await foreach (var msg in rc.StartReplication(slot, streamingCts.Token))
                             messages.Enqueue((msg.WalStart, msg.WalEnd, msg.Data));
                     }, CancellationToken.None);
 


### PR DESCRIPTION
* Public-facing StartReplication methods return IAsyncEnumerable<T> instead of Task<IAsyncEnumerable<T>>. This removes the double-awaiting we currently have.
* Merged some unnecessarily separated methods, all StartReplication logic now sits in async-iterator methods (except thin sync wrappers for NoSynchronizationContextScope above that).
* Made sure [EnumeratorCancellation] is properly set everywhere, making the token passed to StartReplication implicitly get baked into the returned IAsyncEnumerable. This allows removing WithCancellation in call sites.
* Various other small cleanups.