### PR TITLE
Refactor command creation

### DIFF
--- a/Npgsql.sln.DotSettings
+++ b/Npgsql.sln.DotSettings
@@ -88,6 +88,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MSDTC/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=multiquery/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Noda/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NOEXPORT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Npgsql/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Npgsql_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PGTZ/@EntryIndexedValue">True</s:Boolean>

--- a/src/Npgsql/Replication/NpgsqlPhysicalReplicationSlot.cs
+++ b/src/Npgsql/Replication/NpgsqlPhysicalReplicationSlot.cs
@@ -7,7 +7,7 @@ namespace Npgsql.Replication
     /// </summary>
     public class NpgsqlPhysicalReplicationSlot : NpgsqlReplicationSlot
     {
-        internal NpgsqlPhysicalReplicationSlot(string slotName)
-            : base(slotName) { }
+        internal NpgsqlPhysicalReplicationSlot(string name)
+            : base(name) { }
     }
 }

--- a/src/Npgsql/Replication/NpgsqlReplicationSlot.cs
+++ b/src/Npgsql/Replication/NpgsqlReplicationSlot.cs
@@ -5,14 +5,14 @@
     /// </summary>
     public abstract class NpgsqlReplicationSlot
     {
-        internal NpgsqlReplicationSlot(string slotName)
+        internal NpgsqlReplicationSlot(string name)
         {
-            SlotName = slotName;
+            Name = name;
         }
 
         /// <summary>
         /// The name of the newly-created replication slot.
         /// </summary>
-        public string SlotName { get; }
+        public string Name { get; }
     }
 }

--- a/src/Npgsql/Replication/PgOutput/NpgsqlPgOutputConnectionExtensions.cs
+++ b/src/Npgsql/Replication/PgOutput/NpgsqlPgOutputConnectionExtensions.cs
@@ -60,9 +60,10 @@ namespace Npgsql.Replication
             NpgsqlLogicalSlotSnapshotInitMode? slotSnapshotInitMode = null,
             CancellationToken cancellationToken = default)
         {
-            // We don't enter NoSynchronizationContextScope here since we (have to) do it in CreateReplicationSlotForPlugin, because
-            // otherwise it couldn't be set for external plugins.
-            var options = await connection.CreateReplicationSlotForPlugin(slotName, "pgoutput", temporarySlot, slotSnapshotInitMode, cancellationToken);
+            // We don't enter NoSynchronizationContextScope here since we (have to) do it in CreateLogicalReplicationSlot, because
+            // otherwise it wouldn't be set for external plugins.
+            var options = await connection.CreateLogicalReplicationSlot(
+                slotName, "pgoutput", temporarySlot, slotSnapshotInitMode, cancellationToken).ConfigureAwait(false);
             return new NpgsqlPgOutputReplicationSlot(options);
         }
 

--- a/src/Npgsql/Replication/PgOutput/NpgsqlPgOutputReplicationSlot.cs
+++ b/src/Npgsql/Replication/PgOutput/NpgsqlPgOutputReplicationSlot.cs
@@ -40,6 +40,6 @@ namespace Npgsql.Replication.PgOutput
         /// </remarks>
         /// <param name="slot">The <see cref="NpgsqlPgOutputReplicationSlot"/> from which the new instance should be initialized</param>
         protected NpgsqlPgOutputReplicationSlot(NpgsqlPgOutputReplicationSlot slot)
-            : base(slot.OutputPlugin, new NpgsqlReplicationSlotOptions(slot.SlotName, slot.ConsistentPoint, slot.SnapshotName)) { }
+            : base(slot.OutputPlugin, new NpgsqlReplicationSlotOptions(slot.Name, slot.ConsistentPoint, slot.SnapshotName)) { }
     }
 }

--- a/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
@@ -63,14 +63,10 @@ namespace Npgsql.Replication.PgOutput
 
         async IAsyncEnumerator<LogicalReplicationProtocolMessage> StartReplicationInternal(CancellationToken cancellationToken)
         {
-            var stream = _connection.StartReplicationInternal(commandBuilder =>
-            {
-                commandBuilder.Append("SLOT ").Append(_slot.SlotName).Append(' ');
-                NpgsqlLogicalReplicationConnectionExtensions.AppendCommon(
-                    commandBuilder, _walLocation, _options.GetOptionPairs(), _slot.ConsistentPoint);
-            }, bypassingStream: true, cancellationToken);
-
+            var stream = _connection.StartLogicalReplication(
+                _slot, cancellationToken, _walLocation, _options.GetOptionPairs(), bypassingStream: true);
             var buf = _connection.Connector!.ReadBuffer;
+
             await foreach (var xLogData in stream.WithCancellation(cancellationToken))
             {
                 await buf.EnsureAsync(1, cancellationToken);

--- a/src/Npgsql/Replication/TestDecoding/NpgsqlTestDecodingConnectionExtensions.cs
+++ b/src/Npgsql/Replication/TestDecoding/NpgsqlTestDecodingConnectionExtensions.cs
@@ -59,9 +59,9 @@ namespace Npgsql.Replication
             CancellationToken cancellationToken = default)
         {
             // We don't enter NoSynchronizationContextScope here since we (have to) do it in CreateReplicationSlotForPlugin, because
-            // otherwise it couldn't be set for external plugins.
-            var options =
-                await connection.CreateReplicationSlotForPlugin(slotName, "test_decoding", temporarySlot, slotSnapshotInitMode, cancellationToken);
+            // otherwise it wouldn't be set for external plugins.
+            var options = await connection.CreateLogicalReplicationSlot(
+                slotName, "test_decoding", temporarySlot, slotSnapshotInitMode, cancellationToken).ConfigureAwait(false);
             return new NpgsqlTestDecodingReplicationSlot(options);
         }
 
@@ -93,7 +93,7 @@ namespace Npgsql.Replication
             [EnumeratorCancellation] CancellationToken cancellationToken, NpgsqlTestDecodingPluginOptions options = default,
             NpgsqlLogSequenceNumber? walLocation = null)
         {
-            var stream = connection.StartReplicationForPlugin(slot, cancellationToken, walLocation, options.GetOptionPairs());
+            var stream = connection.StartLogicalReplication(slot, cancellationToken, walLocation, options.GetOptionPairs());
 
             await foreach (var msg in stream.WithCancellation(cancellationToken))
             {

--- a/test/Npgsql.Tests/Replication/CommonLogicalReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonLogicalReplicationTests.cs
@@ -36,7 +36,7 @@ namespace Npgsql.Tests.Replication
                         TestUtil.MinimumPgVersion(c, "10.0", "Temporary replication slots were introduced in PostgreSQL 10");
 
                     await using var rc = await OpenReplicationConnectionAsync();
-                    var options = await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin, temporary);
+                    var options = await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, temporary);
 
                     using var cmd =
                         new NpgsqlCommand($"SELECT * FROM pg_replication_slots WHERE slot_name = '{options.SlotName}'",
@@ -62,7 +62,7 @@ namespace Npgsql.Tests.Replication
                     await using var c = await OpenConnectionAsync();
                     TestUtil.MinimumPgVersion(c, "10.0", "The *_SNAPSHOT syntax was introduced in PostgreSQL 10");
                     await using var rc = await OpenReplicationConnectionAsync();
-                    var options = await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin, slotSnapshotInitMode: NpgsqlLogicalSlotSnapshotInitMode.NoExport);
+                    var options = await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, slotSnapshotInitMode: NpgsqlLogicalSlotSnapshotInitMode.NoExport);
                     Assert.That(options.SnapshotName, Is.Null);
                 });
 
@@ -79,7 +79,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(async () =>
                     {
                         await using var rc = await OpenReplicationConnectionAsync();
-                        await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin, slotSnapshotInitMode: mode);
+                        await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, slotSnapshotInitMode: mode);
                     }, Throws.ArgumentException
                         .With.Property("ParamName").EqualTo("slotSnapshotInitMode")
                         .And.Message.StartsWith("The EXPORT_SNAPSHOT, USE_SNAPSHOT and NOEXPORT_SNAPSHOT syntax was introduced in PostgreSQL")
@@ -101,7 +101,7 @@ namespace Npgsql.Tests.Replication
                         transaction.Commit();
                     }
                     await using var rc = await OpenReplicationConnectionAsync();
-                    var options = await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin, slotSnapshotInitMode: NpgsqlLogicalSlotSnapshotInitMode.Export);
+                    var options = await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, slotSnapshotInitMode: NpgsqlLogicalSlotSnapshotInitMode.Export);
                     await using (var transaction = c.BeginTransaction())
                     {
                         await c.ExecuteNonQueryAsync($"INSERT INTO {tableName} (value) VALUES('After snapshot')");
@@ -130,7 +130,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(async () =>
                     {
                         await using var rc = await OpenReplicationConnectionAsync();
-                        await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin, slotSnapshotInitMode: NpgsqlLogicalSlotSnapshotInitMode.Use);
+                        await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, slotSnapshotInitMode: NpgsqlLogicalSlotSnapshotInitMode.Use);
                     }, Throws.InstanceOf<PostgresException>()
                         .With.Property("SqlState")
                         .EqualTo("XX000")
@@ -142,7 +142,7 @@ namespace Npgsql.Tests.Replication
             => Assert.That(async () =>
             {
                 await using var rc = await OpenReplicationConnectionAsync();
-                await rc.CreateReplicationSlotForPlugin(null!, OutputPlugin);
+                await rc.CreateLogicalReplicationSlot(null!, OutputPlugin);
             }, Throws.ArgumentNullException
                 .With.Property("ParamName")
                 .EqualTo("slotName"));
@@ -155,7 +155,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(async () =>
                     {
                         await using var rc = await OpenReplicationConnectionAsync();
-                        await rc.CreateReplicationSlotForPlugin(slotName, null!);
+                        await rc.CreateLogicalReplicationSlot(slotName, null!);
                     }, Throws.ArgumentNullException
                         .With.Property("ParamName")
                         .EqualTo("outputPlugin"));
@@ -171,7 +171,7 @@ namespace Npgsql.Tests.Replication
                     {
                         await using var rc = await OpenReplicationConnectionAsync();
                         using var cts = GetCancelledCancellationTokenSource();
-                        await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin, cancellationToken: cts.Token);
+                        await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, cancellationToken: cts.Token);
                     }, Throws.Exception.AssignableTo<OperationCanceledException>());
                     return Task.CompletedTask;
                 });
@@ -184,7 +184,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(async () =>
                     {
                         await using var rc = await OpenReplicationConnectionAsync();
-                        await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin, slotSnapshotInitMode: (NpgsqlLogicalSlotSnapshotInitMode)42);
+                        await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, slotSnapshotInitMode: (NpgsqlLogicalSlotSnapshotInitMode)42);
                     }, Throws.InstanceOf<ArgumentOutOfRangeException>()
                         .With.Property("ParamName")
                         .EqualTo("slotSnapshotInitMode")
@@ -202,7 +202,7 @@ namespace Npgsql.Tests.Replication
                     {
                         var rc = await OpenReplicationConnectionAsync();
                         await rc.DisposeAsync();
-                        await rc.CreateReplicationSlotForPlugin(slotName, OutputPlugin);
+                        await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin);
                     }, Throws.InstanceOf<ObjectDisposedException>()
                         .With.Property(nameof(ObjectDisposedException.ObjectName))
                         .EqualTo(nameof(NpgsqlLogicalReplicationConnection)));

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -468,7 +468,7 @@ namespace Npgsql.Tests.Replication
             {
                 var slot = new NpgsqlPhysicalReplicationSlot(slotName);
                 var rc = (NpgsqlPhysicalReplicationConnection)(NpgsqlReplicationConnection)connection;
-                await foreach (var msg in rc.StartReplication(slot, cancellationToken, xLogPos))
+                await foreach (var msg in rc.StartReplication(slot, xLogPos, cancellationToken))
                 {
                     yield return msg;
                 }

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -21,7 +21,7 @@ namespace Npgsql.Tests.Replication
                     var options = await rc.CreatePgOutputReplicationSlot(slotName);
 
                     using var cmd =
-                        new NpgsqlCommand($"SELECT * FROM pg_replication_slots WHERE slot_name = '{options.SlotName}'",
+                        new NpgsqlCommand($"SELECT * FROM pg_replication_slots WHERE slot_name = '{options.Name}'",
                             c);
                     await using var reader = await cmd.ExecuteReaderAsync();
 

--- a/test/Npgsql.Tests/Replication/PhysicalReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PhysicalReplicationTests.cs
@@ -18,7 +18,7 @@ namespace Npgsql.Tests.Replication
 
                     await using var c = await OpenConnectionAsync();
                     using var cmd =
-                        new NpgsqlCommand($"SELECT * FROM pg_replication_slots WHERE slot_name = '{slot.SlotName}'",
+                        new NpgsqlCommand($"SELECT * FROM pg_replication_slots WHERE slot_name = '{slot.Name}'",
                             c);
                     await using var reader = await cmd.ExecuteReaderAsync();
 
@@ -39,7 +39,7 @@ namespace Npgsql.Tests.Replication
                     var info = await rc.IdentifySystem();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = rc.StartReplication(slot, streamingCts.Token, info.XLogPos).GetAsyncEnumerator();
+                    var messages = rc.StartReplication(slot, info.XLogPos, streamingCts.Token).GetAsyncEnumerator();
 
                     await using var c = await OpenConnectionAsync();
                     await c.ExecuteNonQueryAsync($"CREATE TABLE {tableName} (value text)");

--- a/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
@@ -25,7 +25,7 @@ namespace Npgsql.Tests.Replication
 
                     await using var c = await OpenConnectionAsync();
                     using var cmd =
-                        new NpgsqlCommand($"SELECT * FROM pg_replication_slots WHERE slot_name = '{options.SlotName}'",
+                        new NpgsqlCommand($"SELECT * FROM pg_replication_slots WHERE slot_name = '{options.Name}'",
                             c);
                     await using var reader = await cmd.ExecuteReaderAsync();
 


### PR DESCRIPTION
* Logic for constructing the command strings for slot creation and start replication were pieced together via labdas. Refactored to have the physical and logical commands in one place for each one. (https://github.com/npgsql/npgsql/pull/3281#discussion_r515469678)
* Added missing ConfigureAwait(false) (https://github.com/npgsql/npgsql/pull/3281#discussion_r518764470)
* Some other refactoring/cleanup