### PR TITLE
Timer concurrency logic

### DIFF
--- a/src/Npgsql/Replication/Internal/LogicalReplicationConnectionExtensions.cs
+++ b/src/Npgsql/Replication/Internal/LogicalReplicationConnectionExtensions.cs
@@ -134,11 +134,7 @@ namespace Npgsql.Replication.Internal
             {
                 builder
                     .Append(" (")
-#if NETSTANDARD2_0
                     .Append(string.Join(", ", options.Select(kv => @$"""{kv.Key}""{(kv.Value is null ? "" : $" '{kv.Value}'")}")))
-#else
-                    .AppendJoin(", ", options.Select(kv => @$"""{kv.Key}""{(kv.Value is null ? "" : $" '{kv.Value}'")}"))
-#endif
                     .Append(')');
             }
 

--- a/src/Npgsql/Util/WaitHandleExtensions.cs
+++ b/src/Npgsql/Util/WaitHandleExtensions.cs
@@ -1,0 +1,44 @@
+#if NETSTANDARD2_0
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Npgsql.Util
+{
+    // https://thomaslevesque.com/2015/06/04/async-and-cancellation-support-for-wait-handles/
+    static class WaitHandleExtensions
+    {
+        internal static async Task<bool> WaitOneAsync(
+            this WaitHandle handle, int millisecondsTimeout, CancellationToken cancellationToken  = default)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            using var tokenRegistration =
+                cancellationToken.Register(state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(), tcs);
+
+            RegisteredWaitHandle? registeredHandle = null;
+            try
+            {
+                registeredHandle = ThreadPool.RegisterWaitForSingleObject(
+                    handle,
+                    (state, timedOut) => ((TaskCompletionSource<bool>)state!).TrySetResult(!timedOut),
+                    state: tcs,
+                    millisecondsTimeout,
+                    executeOnlyOnce: true);
+                return await tcs.Task;
+            }
+            finally
+            {
+                registeredHandle?.Unregister(null);
+            }
+        }
+
+        internal static Task<bool> WaitOneAsync(this WaitHandle handle, TimeSpan timeout, CancellationToken cancellationToken  = default)
+            => handle.WaitOneAsync((int)timeout.TotalMilliseconds, cancellationToken);
+
+        internal static Task<bool> WaitOneAsync(this WaitHandle handle, CancellationToken cancellationToken = default)
+            => handle.WaitOneAsync(Timeout.Infinite, cancellationToken);
+    }
+}
+
+#endif


### PR DESCRIPTION
As discussed, this redoes the timer management to (hopefully) remove all race conditions.

* The timer object is only allocated when starting replication, and disposed when exiting it.
* When disposing, we wait until callbacks have completed (this is a bit tricky to do asynchronously on netstandard2.0, but I think it's OK). This means that we can never have timer *callbacks* running when StartReplication has returned.
* A race condition may still make a feedback packet arrive at PG after replication has completed. I have done a check, and PG doesn't mind if a feedback message is received in idle state (outside of replication), so we should be good.
* The above also means that we don't need to suspend the timer when cancelling replication.
* Finally, it's worth noting that if SendFeedback gets stuck (because of a network partition), StartReplication will wait. As far as I can tell, this isn't a problem - we should already have timeouts in place for this case, and there's nothing special with this scenario compared to SendFeedback blocking anywhere else.

/cc @Brar and @vonzshik for an extra pair of eyes for this concurrency-sensitive business